### PR TITLE
Change API to use fancy_regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "umya-spreadsheet is a library written in pure Rust and read and w
 [dependencies]
 quick-xml = { version = "0.17", features = [ "serialize" ] }
 zip = {version = "0.5.6", default-features = false, features = ["deflate"]}
-regex = "1.3.7"
+# regex = "1.3.7"
 md-5 = "0.10.1"
 lazy_static = "1.4.0"
 thousands = "0.2.0"
@@ -23,6 +23,7 @@ encoding_rs = "0.8.30"
 image = "0.24.1"
 hashbrown = "0.12.0"
 ahash = "0.7.6"
+fancy-regex = "0.8.0"
 
 [lib]
 doctest = false

--- a/src/helper/formula.rs
+++ b/src/helper/formula.rs
@@ -1,5 +1,5 @@
 use helper::coordinate::*;
-use regex::{Regex, Captures};
+use fancy_regex::{Regex, Captures};
 
 pub fn adjustment_insert_formula_coordinate(
     formula: &str,

--- a/src/helper/number_format.rs
+++ b/src/helper/number_format.rs
@@ -1,10 +1,46 @@
-//use regex::Regex;
+use fancy_regex::Captures;
+use fancy_regex::Matches;
+use fancy_regex::Regex;
+//use fancy_regex::Regex;
 use helper::date::*;
-use regex::Captures;
-use regex::Regex;
 use structs::Color;
 use structs::NumberingFormat;
 use thousands::Separable;
+
+pub struct Split<'r, 't> {
+    finder: Matches<'r, 't>,
+    last: usize,
+}
+pub fn split<'r, 't>(regex: &'r Regex, text: &'t str) -> Split<'r, 't> {
+    Split {
+        finder: regex.find_iter(text),
+        last: 0,
+    }
+}
+
+impl<'r, 't> Iterator for Split<'r, 't> {
+    type Item = &'t str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let text = self.finder.text();
+        match self.finder.next() {
+            Some(Ok(m)) => {
+                let matched = &text[self.last..m.start()];
+                self.last = m.end();
+                Some(matched)
+            }
+            _ => {
+                if self.last > text.len() {
+                    None
+                } else {
+                    let s = &text[self.last..];
+                    self.last = text.len() + 1;
+                    Some(s)
+                }
+            }
+        }
+    }
+}
 
 const DATE_FORMAT_REPLACEMENTS: &[(&str, &str)] = &[
     // first remove escapes related to non-format characters
@@ -55,6 +91,15 @@ const DATE_FORMAT_REPLACEMENTS_24: &[(&str, &str)] = &[("hh", "%H"), ("h", "%-H"
 
 const DATE_FORMAT_REPLACEMENTS_12: &[(&str, &str)] = &[("hh", "%I"), ("h", "%-I")];
 
+lazy_static! {
+    pub static ref ESCAPE_REGEX: Regex =
+        Regex::new(r#"(\\\(((.)(?!((AM\/PM)|(A\/P)))|([^ ])))(?=(?:[^"]|"[^"]*")*$)"#).unwrap();
+    pub static ref SECTION_REGEX: Regex = Regex::new(r#"(;)(?=(?:[^"]|"[^"]*")*$)"#).unwrap();
+    pub static ref DATE_TIME_REGEX: Regex =
+        Regex::new(r#"(\[\$[A-Z]*-[0-9A-F]*\])*[hmsdy](?=(?:[^"]|"[^"]*")*$)"#).unwrap();
+    pub static ref PERCENT_DOLLAR_REGEX: Regex = Regex::new("%$").unwrap();
+}
+
 pub fn to_formatted_string<S: Into<String>>(value: S, format: S) -> String {
     let mut value = value.into();
     let mut format = format.into();
@@ -63,29 +108,24 @@ pub fn to_formatted_string<S: Into<String>>(value: S, format: S) -> String {
     if value.is_empty() {
         return value;
     }
-
     // is numeric
     match &value.parse::<f64>() {
-        Ok(_) => {}
+        // convert value
+        Ok(val) if format == NumberingFormat::FORMAT_GENERAL => {
+            return val.to_string();
+        }
+        Ok(_) if format == NumberingFormat::FORMAT_TEXT => return value,
         Err(_) => return value,
-    }
-
-    // convert value
-    if &format == NumberingFormat::FORMAT_GENERAL {
-        return value.parse::<f64>().unwrap().to_string();
-    }
-    if &format == NumberingFormat::FORMAT_TEXT {
-        return value;
+        _ => {}
     }
 
     // Convert any other escaped characters to quoted strings, e.g. (\T to "T")
-    let re =
-        Regex::new(r#"(\\\(((.)(?!((AM\/PM)|(A\/P)))|([^ ])))(?=(?:[^"]|"[^"]*")*$)"#).unwrap();
-    format = re.replace_all(&format, r#""$0""#).into();
+
+    format = ESCAPE_REGEX.replace_all(&format, r#""$0""#).into();
 
     // Get the sections, there can be up to four sections, separated with a semi-colon (but only if not a quoted literal)
-    let re = Regex::new(r#"(;)(?=(?:[^"]|"[^"]*")*$)"#).unwrap();
-    let sections: Vec<&str> = re.split(&format).collect();
+
+    let sections: Vec<&str> = split(&SECTION_REGEX, &format).collect();
 
     let (_, split_format, split_value) = split_format(sections, &value.parse::<f64>().unwrap());
     format = split_format;
@@ -99,15 +139,14 @@ pub fn to_formatted_string<S: Into<String>>(value: S, format: S) -> String {
     // Let's begin inspecting the format and converting the value to a formatted string
 
     //  Check for date/time characters (not inside quotes)
-    let re = Regex::new(r#"(\[\$[A-Z]*-[0-9A-F]*\])*[hmsdy](?=(?:[^"]|"[^"]*")*$)"#).unwrap();
-    let re2 = Regex::new("%$").unwrap();
-    if re.find(&format).is_some() {
+
+    if DATE_TIME_REGEX.is_match(&format).unwrap_or(false) {
         // datetime format
         value = format_as_date(&value.parse::<f64>().unwrap(), &format);
-    } else if &format.starts_with('"') == &true && &format.ends_with('"') == &true {
+    } else if format.starts_with('"') && format.ends_with('"') {
         let conv_format = format.trim_matches('"').parse::<f64>().unwrap();
         value = conv_format.to_string();
-    } else if re2.find(&format).is_some() {
+    } else if PERCENT_DOLLAR_REGEX.is_match(&format).unwrap_or(false) {
         // % number format
         value = format_as_percentage(&value.parse::<f64>().unwrap(), &format);
     } else {
@@ -173,9 +212,9 @@ fn split_format(sections: Vec<&str>, value: &f64) -> (String, String, String) {
     ];
     sections.into_iter().enumerate().for_each(|(idx, section)| {
         let mut converted_section = section.to_string();
-        if color_re.find(section).is_some() {
+        if color_re.find(section).ok().flatten().is_some() {
             let mut item: Vec<String> = Vec::new();
-            for ite in color_re.captures(section).unwrap().iter() {
+            for ite in color_re.captures(section).ok().flatten().unwrap().iter() {
                 item.push(ite.unwrap().as_str().to_string());
             }
             let _ = std::mem::replace(&mut colors[idx], item.get(0).unwrap().to_string());
@@ -183,7 +222,7 @@ fn split_format(sections: Vec<&str>, value: &f64) -> (String, String, String) {
         }
         if cond_regex.contains(section) {
             let mut item: Vec<String> = Vec::new();
-            for ite in cond_re.captures(section).unwrap().iter() {
+            for ite in cond_re.captures(section).ok().flatten().unwrap().iter() {
                 item.push(ite.unwrap().as_str().to_string());
             }
             let _ = std::mem::replace(&mut condops[idx], item.get(1).unwrap().to_string());
@@ -269,7 +308,7 @@ fn format_as_date(value: &f64, format: &str) -> String {
     let mut i = 0;
     for block in blocks {
         let mut block = block.to_string();
-        if &i % &2 == 0 {
+        if i % 2 == 0 {
             for (before, after) in DATE_FORMAT_REPLACEMENTS {
                 block = block.replace(before, after);
             }
@@ -277,7 +316,7 @@ fn format_as_date(value: &f64, format: &str) -> String {
                 // 24-hour time format
                 // when [h]:mm format, the [h] should replace to the hours of the value * 24
                 if block.find("[h]") != None {
-                    let hours = value * &24f64;
+                    let hours = value * 24f64;
                     block = block.replace("[h]", hours.to_string().as_str());
                     converted_blocks.push(block);
                     continue;
@@ -310,6 +349,15 @@ fn format_as_date(value: &f64, format: &str) -> String {
 }
 
 fn format_as_number(value: &f64, format: &str) -> String {
+    lazy_static! {
+        static ref THOUSANDS_SEP_REGEX: Regex = Regex::new(r#"(#,#|0,0)"#).unwrap();
+        static ref SCALE_REGEX: Regex = Regex::new(r#"(#|0)(,+)"#).unwrap();
+        static ref TRAILING_COMMA_REGEX: Regex = Regex::new("(#|0),+").unwrap();
+        static ref FRACTION_REGEX: Regex = Regex::new(r#"#?.*\?{1,2}\/\?{1,2}"#).unwrap();
+        static ref SQUARE_BRACKET_REGEX: Regex = Regex::new(r#"\[[^\]]+\]"#).unwrap();
+        static ref NUMBER_REGEX: Regex = Regex::new(r#"(0+)(\.?)(0*)"#).unwrap();
+    }
+
     let mut value = value.to_string();
 
     // The "_" in this string has already been stripped out,
@@ -325,35 +373,38 @@ fn format_as_number(value: &f64, format: &str) -> String {
     // Find out if we need thousands separator
     // This is indicated by a comma enclosed by a digit placeholder:
     //        #,#   or   0,0
-    let re = Regex::new(r#"(#,#|0,0)"#).unwrap();
+
     let converted_format_clone = format.clone();
-    let use_thousands = re.find(&converted_format_clone).is_some();
-    if &use_thousands == &true {
-        format = Regex::new("0,0").unwrap().replace_all(&format, "00").into();
-        format = Regex::new("#,#").unwrap().replace_all(&format, "##").into();
+    let use_thousands = THOUSANDS_SEP_REGEX
+        .find(&converted_format_clone)
+        .ok()
+        .flatten()
+        .is_some();
+    if use_thousands {
+        format = format.replace("0,0", "00");
+        format = format.replace("#,#", "##");
     }
 
     // Scale thousands, millions,...
     // This is indicated by a number of commas after a digit placeholder:
     //        #,   or    0.0,,
     let mut scale: f64 = 1f64; // same as no scale
-    let re = Regex::new(r#"(#|0)(,+)"#).unwrap();
-    if re.find(&format).is_some() {
+
+    if SCALE_REGEX.is_match(&format).unwrap_or(false) {
         let mut matches: Vec<String> = Vec::new();
-        for ite in re.captures(&format).unwrap().iter() {
+        for ite in SCALE_REGEX.captures(&format).ok().flatten().unwrap().iter() {
             matches.push(ite.unwrap().as_str().to_string());
         }
         scale = 1000i32.pow(matches[2].len() as u32) as f64;
 
         // strip the commas
-        format = Regex::new("0,+").unwrap().replace_all(&format, "0").into();
-        format = Regex::new("#,+").unwrap().replace_all(&format, "#").into();
+        format = TRAILING_COMMA_REGEX.replace_all(&format, "$1").into()
     }
-
-    if Regex::new(r#"#?.*\?\/\?"#).unwrap().find(&format).is_some() {
+    if FRACTION_REGEX.is_match(&format).unwrap_or(false) {
         match &value.parse::<usize>() {
             Ok(_) => {}
             Err(_) => {
+                println!("format as fraction {} {}", value, format);
                 value = format_as_fraction(&value.parse::<f64>().unwrap(), &format);
             }
         }
@@ -363,39 +414,35 @@ fn format_as_number(value: &f64, format: &str) -> String {
         // scale number
         value = (value.parse::<f64>().unwrap() / scale).to_string();
         // Strip #
-        format = Regex::new(r#"\#"#)
-            .unwrap()
-            .replace_all(&format, "0")
-            .into();
+        format = format.replace('#', "0");
         // Remove \
-        format = Regex::new(r#"\\"#).unwrap().replace_all(&format, "").into();
+        format = format.replace('\\', "");
         // Remove locale code [$-###]
-        format = Regex::new(r#"\[\$\-.*\]"#)
-            .unwrap()
-            .replace_all(&format, "")
-            .into();
+        format = format.replace("[$-.*]", "");
         // Trim
         format = format.trim().to_string();
 
-        let m = Regex::new(r#"\[[^\]]+\]"#)
-            .unwrap()
-            .replace_all(&format, "");
-        let number_regex = r#"(0+)(\.?)(0*)"#;
-        let re = Regex::new(number_regex).unwrap();
-        if re.find(&m).is_some() {
+        let m = SQUARE_BRACKET_REGEX.replace_all(&format, "");
+
+        if NUMBER_REGEX.is_match(&m).unwrap_or(false) {
             let mut item: Vec<String> = Vec::new();
-            for ite in re.captures(&m).unwrap().iter() {
+            for ite in NUMBER_REGEX.captures(&m).ok().flatten().unwrap().iter() {
                 item.push(ite.unwrap().as_str().to_string());
             }
-            value =
-                format_straight_numeric_value(&value, &format, &item, &use_thousands, number_regex);
+            value = format_straight_numeric_value(
+                &value,
+                &format,
+                &item,
+                &use_thousands,
+                r#"(0+)(\.?)(0*)"#,
+            );
         }
     }
 
     let re = Regex::new(r#"\$[^0-9]*"#).unwrap();
-    if re.find(&format).is_some() {
+    if re.find(&format).ok().flatten().is_some() {
         let mut item: Vec<String> = Vec::new();
-        for ite in re.captures(&format).unwrap().iter() {
+        for ite in re.captures(&format).ok().flatten().unwrap().iter() {
             item.push(ite.unwrap().as_str().to_string());
         }
         value = format!("{}{}", item.get(0).unwrap(), value);
@@ -425,10 +472,10 @@ fn format_as_fraction(value: &f64, format: &str) -> String {
 
     let gcd = gcd(&decimal_part, &decimal_divisor);
 
-    let mut adjusted_decimal_part = &decimal_part / &gcd;
-    let adjusted_decimal_divisor = &decimal_divisor / &gcd;
+    let mut adjusted_decimal_part = decimal_part / gcd;
+    let adjusted_decimal_divisor = decimal_divisor / gcd;
 
-    let mut result = String::from("");
+    let result;
     match format.find('0') {
         Some(_) => {
             result = format!(
@@ -462,7 +509,7 @@ fn format_as_fraction(value: &f64, format: &str) -> String {
                         &sign, &integer_part_str, &adjusted_decimal_part, &adjusted_decimal_divisor
                     );
                 } else {
-                    adjusted_decimal_part += &integer_part * &adjusted_decimal_divisor;
+                    adjusted_decimal_part += integer_part * adjusted_decimal_divisor;
                     result = format!(
                         "{}{}/{}",
                         &sign, &adjusted_decimal_part, &adjusted_decimal_divisor
@@ -477,7 +524,7 @@ fn format_as_fraction(value: &f64, format: &str) -> String {
 fn format_straight_numeric_value(
     value: &str,
     _format: &str,
-    matches: &Vec<String>,
+    matches: &[String],
     use_thousands: &bool,
     _number_regex: &str,
 ) -> String {
@@ -542,23 +589,20 @@ fn format_straight_numeric_value(
     //    value
 }
 
-fn _merge_complex_number_format_masks(numbers: &Vec<String>, masks: &Vec<String>) -> Vec<String> {
+fn _merge_complex_number_format_masks(numbers: &[String], masks: &[String]) -> Vec<String> {
     let mut decimal_count = numbers[1].len();
     let mut post_decimal_masks: Vec<String> = Vec::new();
 
     for mask in masks.iter().rev() {
         post_decimal_masks.push(mask.to_string());
         decimal_count -= mask.to_string().len();
-        if decimal_count <= 0 {
+        if decimal_count == 0 {
             break;
         }
     }
 
     post_decimal_masks.reverse();
-    let mut result: Vec<String> = Vec::new();
-    result.push(masks.join("."));
-    result.push(post_decimal_masks.join("."));
-    result
+    vec![masks.join("."), post_decimal_masks.join(".")]
 }
 
 fn _process_complex_number_format_mask(number: &f64, mask: &str) -> String {
@@ -568,10 +612,10 @@ fn _process_complex_number_format_mask(number: &f64, mask: &str) -> String {
     let mut masking_blocks: Vec<(String, usize)> = Vec::new();
     let mut masking_str: Vec<String> = Vec::new();
     let mut masking_beg: Vec<usize> = Vec::new();
-    for ite in re.captures(&mask).unwrap().iter() {
+    for ite in re.captures(&mask).ok().flatten().unwrap().iter() {
         masking_str.push(ite.unwrap().as_str().to_string());
     }
-    for pos in re.captures(&mask).unwrap().iter() {
+    for pos in re.captures(&mask).ok().flatten().unwrap().iter() {
         let beg = pos.unwrap().start();
         masking_beg.push(beg);
     }
@@ -590,7 +634,7 @@ fn _process_complex_number_format_mask(number: &f64, mask: &str) -> String {
             let size = block.len();
             offset = *pos;
 
-            let block_value = format!("{:0width$}", (&number % &divisor), width = size);
+            let block_value = format!("{:0width$}", (number % divisor), width = size);
 
             number = (number / divisor) as f64;
             let from: String = mask.chars().skip(offset).take(size).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ extern crate image;
 extern crate md5;
 // extern crate onig;
 extern crate quick_xml;
-extern crate regex;
+extern crate fancy_regex;
 extern crate thousands;
 extern crate zip;
 extern crate hashbrown;

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -285,8 +285,10 @@ impl Cell {
 
         // convert value
         let result = match self.get_style().get_number_format() {
-            Some(nmuber_format) => to_formatted_string(value, nmuber_format.get_format_code()),
-            None => to_formatted_string(value, NumberingFormat::FORMAT_GENERAL),
+            Some(nmuber_format) => {
+                to_formatted_string(&value, &nmuber_format.get_format_code())
+            }
+            None => to_formatted_string(&value, &NumberingFormat::FORMAT_GENERAL),
         };
         result
     }

--- a/src/structs/text.rs
+++ b/src/structs/text.rs
@@ -1,10 +1,10 @@
 // t
 use md5::Digest;
 // use onig::*;
+use fancy_regex::Regex;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
-use regex::Regex;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -55,7 +55,7 @@ impl Text {
         lazy_static! {
             static ref RE: Regex = Regex::new(r#"^(\s|　)"#).unwrap();
         }
-        if RE.find(&self.value).is_some() {
+        if RE.find(&self.value).ok().flatten().is_some() {
             attributes.push(("xml:space", "preserve"));
         }
         write_start_tag(writer, "t", attributes, false);


### PR DESCRIPTION
The regex crate does not support lookaheads, so we use `fancy_regex`, which is based on `regex` an enhances it to support look aheads.